### PR TITLE
Remove release_repo_url from tracks.

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -19,7 +19,6 @@ tracks:
     name: upstream_foxy
     patches: null
     release_inc: '1'
-    release_repo_url: git@github.com:moveit/warehouse_ros_mongo-release.git
     release_tag: :{version}
     ros_distro: foxy
     vcs_type: git
@@ -45,7 +44,6 @@ tracks:
     name: upstream_foxy
     patches: null
     release_inc: '1'
-    release_repo_url: git@github.com:moveit/warehouse_ros_mongo-release.git
     release_tag: :{version}
     ros_distro: galactic
     vcs_type: git
@@ -71,7 +69,6 @@ tracks:
     name: upstream_foxy
     patches: null
     release_inc: '1'
-    release_repo_url: git@github.com:moveit/warehouse_ros_mongo-release.git
     release_tag: :{version}
     ros_distro: rolling
     vcs_type: git


### PR DESCRIPTION
Bloom generally gets the release repo from the ros/rosdistro distribution.yaml file. Configuring it in the tracks.yaml is optional and can create configuration conflicts if the value in tracks differs from the value in the distribution.yaml.